### PR TITLE
Reintroduce Passport Authentication to Movie Endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,14 +44,14 @@ app.get('/', (req, res) => { res.status(200).send('Welcome to Cinephile!');});
 
 const authenticate = passport.authenticate('jwt', { session: false });
 
-app.get('/movies', movies.readAll);
-app.get('/movies/search', movies.search);
-app.get('/movies/featured', movies.readFeatured);
-app.get('/movies/:title', movies.read);
-app.get('/movies/genre/:name', movies.readGenre);
-app.get('/movies/:title/genre', movies.readGenreByTitle);
-app.get('/movies/director/:name', movies.readDirector);
-app.get('/movies/:title/director', movies.readDirectorByTitle);
+app.get('/movies', authenticate, movies.readAll);
+app.get('/movies/search', authenticate, movies.search);
+app.get('/movies/featured', authenticate, movies.readFeatured);
+app.get('/movies/:title', authenticate, movies.read);
+app.get('/movies/genre/:name', authenticate, movies.readGenre);
+app.get('/movies/:title/genre', authenticate, movies.readGenreByTitle);
+app.get('/movies/director/:name', authenticate, movies.readDirector);
+app.get('/movies/:title/director', authenticate, movies.readDirectorByTitle);
 
 
 const validateSignup = [ 


### PR DESCRIPTION
This pull request reintroduces passport-authenticate to all movie-related endpoints in the server. 

The `authenticate` middleware was temporarily removed to facilitate the setup of fetch and PropTypes in the client application. Now that the client setup is complete, the `authenticate` middleware has been added back to ensure that only authenticated requests can access these endpoints.

The following endpoints are affected:

- GET /movies
- GET /movies/search
- GET /movies/featured
- GET /movies/:title
- GET /movies/genre/:name
- GET /movies/:title/genre
- GET /movies/director/:name
- GET /movies/:title/director
